### PR TITLE
go-outdoors

### DIFF
--- a/brands/shop/outdoor.json
+++ b/brands/shop/outdoor.json
@@ -50,6 +50,15 @@
       "shop": "outdoor"
     }
   },
+  "shop/outdoor|Go Outdoors": {
+    "countryCodes": ["gb"],
+    "tags": {
+      "brand": "Go Outdoors",
+      "brand:wikidata": "Q75293941",
+      "name": "Go Outdoors",
+      "shop": "outdoor"
+    }
+  },
   "shop/outdoor|Jack Wolfskin": {
     "countryCodes": ["ch", "de", "fr"],
     "matchTags": ["shop/clothes"],


### PR DESCRIPTION
Add Go Outdoors, UK chain with 70 stores (owned by JD Sports)